### PR TITLE
Compile Python bindings

### DIFF
--- a/vehicle-python/src/vehicle_lang/__init__.py
+++ b/vehicle-python/src/vehicle_lang/__init__.py
@@ -13,15 +13,18 @@ from .typing import AnyOptimiser as AnyOptimiser
 from .typing import AnyOptimisers as AnyOptimisers
 from .typing import DeclarationName as DeclarationName
 from .typing import DifferentiableLogic as DifferentiableLogic
+from .typing import QueryFormat as QueryFormat
 from .typing import Optimiser as Optimiser
 from .typing import QuantifiedVariableName as QuantifiedVariableName
 from .typing import Verifier as Verifier
 from .verify import verify as verify
+from .compile import compile_to_query as compile_to_query
 
 __all__: List[str] = [
     "VERSION",
     # Compile
     "load_loss_function",
+	"compile_to_query",
     # Verify
     "verify",
     # Error types
@@ -38,5 +41,6 @@ __all__: List[str] = [
     "AnyOptimiser",
     "AnyOptimisers",
     "DifferentiableLogic",
+	"QueryFormat",
     "Verifier",
 ]

--- a/vehicle-python/src/vehicle_lang/compile/__init__.py
+++ b/vehicle-python/src/vehicle_lang/compile/__init__.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Iterable, Optional, Union
 
 from .. import session
 from ..typing import DeclarationName, DifferentiableLogic, QueryFormat
+from .error import VehicleError as VehicleError
 
 
 def compile_to_query(
@@ -59,17 +60,12 @@ def compile_to_query(
     if cache is not None:
         args.extend(["--cache", str(cache)])
 
-    print(args)
-
     # Call Vehicle
-    # exec, out, err, _ = session.check_output(args)
+    exec, out, err, _ = session.check_output(args)
 
-    # if exec != 0:
-    #     raise VehicleError(f"Vehicle exited with code {exec}: {err}")
-    # if not out:
-    #     raise VehicleError(f"Vehicle produced no output: {err}")
+    if exec != 0:
+        raise VehicleError(f"{err}")
+    elif not out:
+        raise VehicleError(f"Vehicle produced no output")
 
-    exec, out = session.check_output(args)
-
-    # Check for errors
     return out

--- a/vehicle-python/src/vehicle_lang/compile/__init__.py
+++ b/vehicle-python/src/vehicle_lang/compile/__init__.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Union
+
+from .. import session
+from ..typing import DeclarationName, DifferentiableLogic, QueryFormat
+
+
+def compile_to_query(
+    path: Union[str, Path],
+    target: Union[DifferentiableLogic, QueryFormat],
+    declarations: Optional[Iterable[DeclarationName]] = None,
+    networks: Dict[DeclarationName, Union[str, Path]] = {},
+    datasets: Dict[DeclarationName, Union[str, Path]] = {},
+    parameters: Dict[DeclarationName, Any] = {},
+    output_file: Optional[Union[str, Path]] = None,
+    module_name: Optional[str] = None,
+    cache: Optional[Union[str, Path]] = None,
+) -> str:
+    """
+    Compile a Vehicle specification to a query language (e.g., Marabou, VNNLIB etc.)
+
+    :param specification: The path to the Vehicle specification file to compile.
+    :param target: The target language to compile to (e.g., QueryFormat.Marabou).
+    :param declarations: The names of the declarations to compile, defaults to all declarations.
+    :param networks: A map from the network names in the specification to files containing the networks.
+    :param datasets: A map from the dataset names in the specification to files containing the datasets.
+    :param parameters: A map from the parameter names in the specification to the values to be used in compilation.
+    :param output_file: Output location for the compiled file(s). Defaults to stdout if not provided.
+    :param module_name: Override the name of the exported module (for ITP targets).
+    :param cache: The location of the verification cache for ITP compilation.
+    """
+
+    args = ["compile", "--specification", str(path), "--target", target._vehicle_option_name]
+
+    # Add declarations if specified
+    if declarations is not None:
+        for declaration_name in set(declarations):
+            args.extend(["--declaration", declaration_name])
+
+    # Add networks, datasets, and parameters
+    for network_name, network_path in networks.items():
+        args.extend(["--network", f"{network_name}:{network_path}"])
+
+    for dataset_name, dataset_path in datasets.items():
+        args.extend(["--dataset", f"{dataset_name}:{dataset_path}"])
+
+    for parameter_name, parameter_value in parameters.items():
+        args.extend(["--parameter", f"{parameter_name}:{parameter_value}"])
+
+    # Add output file if specified
+    if output_file is not None:
+        args.extend(["--output", str(output_file)])
+
+    # Add module name if specified
+    if module_name is not None:
+        args.extend(["--module-name", module_name])
+
+    # Add cache if specified
+    if cache is not None:
+        args.extend(["--cache", str(cache)])
+
+    print(args)
+
+    # Call Vehicle
+    # exec, out, err, _ = session.check_output(args)
+
+    # if exec != 0:
+    #     raise VehicleError(f"Vehicle exited with code {exec}: {err}")
+    # if not out:
+    #     raise VehicleError(f"Vehicle produced no output: {err}")
+
+    exec, out = session.check_output(args)
+
+    # Check for errors
+    return out

--- a/vehicle-python/src/vehicle_lang/session/__init__.py
+++ b/vehicle-python/src/vehicle_lang/session/__init__.py
@@ -1,5 +1,6 @@
 import atexit
 import io
+import os
 import sys
 from contextlib import AbstractContextManager, redirect_stderr, redirect_stdout
 from types import TracebackType
@@ -73,26 +74,31 @@ class Session(SessionContextManager):
             return _unsafe_vehicle_main(args)
         else:
             raise VehicleSessionClosed()
+                
+    def check_output(self, args: Sequence[str]):
+        stdout_fd = sys.stdout.fileno()
+        read_fd, write_fd = os.pipe()
 
-    def check_output(
-        self,
-        args: Sequence[str],
-    ) -> Tuple[int, Optional[str], Optional[str], Optional[str]]:
-        with redirect_stdout(io.StringIO()) as out:
-            with redirect_stderr(io.StringIO()) as err:
-                with temporary_files("log", prefix="vehicle") as (log,):
-                    exitCode = self.check_call(
-                        [
-                            f"--redirect-logs={log}",
-                            *args,
-                        ]
-                    )
-                    return (
-                        exitCode,
-                        out.getvalue() or None,
-                        err.getvalue() or None,
-                        log.read_text(),
-                    )
+        saved_stdout_fd = os.dup(stdout_fd)       # Save stdout file description
+        os.dup2(write_fd, stdout_fd)              # Redirect stdout to pipe
+
+        try:
+            with temporary_files("log", prefix="vehicle") as (log,):
+                exitCode = self.check_call(
+                    [f"--redirect-logs={log}", *args]
+                )
+            sys.stdout.flush()
+        finally:
+            os.close(stdout_fd)             # Close stdout file descriptor (to send EOF)
+            os.close(write_fd)              # Close write end of pipe
+
+        with os.fdopen(read_fd) as f:
+            output = f.read()
+
+        os.dup2(saved_stdout_fd, stdout_fd)       # Restore the original stdout file descriptor
+        os.close(saved_stdout_fd)                
+
+        return exitCode, output
 
     def close(self) -> None:
         if not self.closed:

--- a/vehicle-python/src/vehicle_lang/session/__init__.py
+++ b/vehicle-python/src/vehicle_lang/session/__init__.py
@@ -1,5 +1,5 @@
 import atexit
-import io
+import pty
 import os
 import sys
 from contextlib import AbstractContextManager, redirect_stderr, redirect_stdout
@@ -75,30 +75,64 @@ class Session(SessionContextManager):
         else:
             raise VehicleSessionClosed()
                 
-    def check_output(self, args: Sequence[str]):
+    def check_output(
+        self, 
+        args: Sequence[str]
+    ) -> Tuple[int, Optional[str], Optional[str], Optional[str]]:
         stdout_fd = sys.stdout.fileno()
-        read_fd, write_fd = os.pipe()
+        stderr_fd = sys.stderr.fileno()
 
-        saved_stdout_fd = os.dup(stdout_fd)       # Save stdout file description
-        os.dup2(write_fd, stdout_fd)              # Redirect stdout to pipe
+        # Create a pseudo-terminal pair to capture stdout
+        master_fd, slave_fd = pty.openpty() 
+        # Create a pipe to capture stderr
+        pread_fd, pwrite_fd = os.pipe()
+
+        saved_stdout_fd = os.dup(stdout_fd) 
+        saved_stderr_fd = os.dup(stderr_fd)
 
         try:
+            # Redirect stdout and stderr
+            os.dup2(slave_fd, stdout_fd)  
+            os.dup2(pwrite_fd, stderr_fd)
+
+            # Close unused write ends
+            os.close(slave_fd)  
+            os.close(pwrite_fd)
+
             with temporary_files("log", prefix="vehicle") as (log,):
                 exitCode = self.check_call(
                     [f"--redirect-logs={log}", *args]
                 )
+
             sys.stdout.flush()
+
         finally:
-            os.close(stdout_fd)             # Close stdout file descriptor (to send EOF)
-            os.close(write_fd)              # Close write end of pipe
+            # Restore stdout and stderr
+            os.dup2(saved_stdout_fd, stdout_fd)
+            os.dup2(saved_stderr_fd, stderr_fd)
 
-        with os.fdopen(read_fd) as f:
-            output = f.read()
+            # Cleanup
+            os.close(saved_stdout_fd)
+            os.close(saved_stderr_fd)
 
-        os.dup2(saved_stdout_fd, stdout_fd)       # Restore the original stdout file descriptor
-        os.close(saved_stdout_fd)                
+        out_lines = []
 
-        return exitCode, output
+        with os.fdopen(master_fd, "r") as f:    
+            try:
+                while line := f.readline():
+                    out_lines.append(line)
+            except OSError:
+                pass
+
+        with os.fdopen(pread_fd, "r") as f:  
+            err = f.read()
+
+        return (
+                exitCode,
+                "".join(out_lines) or None,
+                err or None,
+                log.read_text(),
+            )
 
     def close(self) -> None:
         if not self.closed:

--- a/vehicle-python/src/vehicle_lang/session/__init__.py
+++ b/vehicle-python/src/vehicle_lang/session/__init__.py
@@ -2,6 +2,7 @@ import atexit
 import pty
 import os
 import sys
+import io
 from contextlib import AbstractContextManager, redirect_stderr, redirect_stdout
 from types import TracebackType
 from typing import TYPE_CHECKING, ClassVar, List, Optional, Sequence, Tuple, Type
@@ -74,8 +75,28 @@ class Session(SessionContextManager):
             return _unsafe_vehicle_main(args)
         else:
             raise VehicleSessionClosed()
-                
+        
     def check_output(
+        self,
+        args: Sequence[str],
+    ) -> Tuple[int, Optional[str], Optional[str], Optional[str]]:
+        with redirect_stdout(io.StringIO()) as out:
+            with redirect_stderr(io.StringIO()) as err:
+                with temporary_files("log", prefix="vehicle") as (log,):
+                    exitCode = self.check_call(
+                        [
+                            f"--redirect-logs={log}",
+                            *args,
+                        ]
+                    )
+                    return (
+                        exitCode,
+                        out.getvalue() or None,
+                        err.getvalue() or None,
+                        log.read_text(),
+                    )
+                
+    def check_output_pty(
         self, 
         args: Sequence[str]
     ) -> Tuple[int, Optional[str], Optional[str], Optional[str]]:

--- a/vehicle-python/src/vehicle_lang/typing.py
+++ b/vehicle-python/src/vehicle_lang/typing.py
@@ -86,6 +86,24 @@ class DifferentiableLogic(Enum):
             DifferentiableLogic.Product: "ProductLoss",
             DifferentiableLogic.Yager: "YagerLoss",
         }[self]
+    
+
+class QueryFormat(Enum):
+    """
+    The query formats supported by Vehicle.
+    """
+
+    VNNLib = 1
+    Marabou = 2
+    Agda = 3
+
+    @property
+    def _vehicle_option_name(self) -> str:
+        return {
+            QueryFormat.VNNLib: "VNNLibQueries",
+            QueryFormat.Marabou: "MarabouQueries",
+            QueryFormat.Agda: "Agda"
+        }[self]
 
 
 class Verifier(Enum):


### PR DESCRIPTION
- Add function 'check_output_py' for redirecting stdout using pseudoterminal (so that it works for vehicle verify and compile commands). This is a placeholder until the verify and compile commands are fixed to correctly print to stdout.
- Add class QueryFormat in typing.py to represent the different query types that vehicle can compile to (e.g., Marabou Queries, Adga, VNNLIB, etc.)
- Add Python function 'compile_to_query' to call the vehicle compile command. 